### PR TITLE
Moves styling names from id's to classes

### DIFF
--- a/src/browser/components/atoms/form-input/index.js
+++ b/src/browser/components/atoms/form-input/index.js
@@ -8,7 +8,7 @@ export default class FormInput extends Component {
   render() {
     return (
         <div className="uk-form-controls">
-            <input className="uk-input" id="form-horizontal-text" type="text" placeholder="Here's a hint to help..." />
+            <input className="uk-input form-horizontal-text" type="text" placeholder="Here's a hint to help..." />
         </div>
     )
   }

--- a/src/browser/components/atoms/select-tag/index.js
+++ b/src/browser/components/atoms/select-tag/index.js
@@ -2,18 +2,20 @@ import React, {Component} from 'react'
 
 export default class SelectTag extends Component {
   render() {
-    const options = this.props.options.map((option, index) => <option key={index} value={option}>{option}</option>)
+    const options = this.props.options.map((option, index) => {
+      return (<option key={index} value={option}>{option}</option>)
+    })
+
     return (
       <div className="uk-margin">
         <label className="uk-form-label" htmlFor="form-horizontal-select">{this.props.label}</label>
         <div className="uk-form-controls">
-          <select className="uk-select" id="form-horizontal-select" onChange={this.props.onChange} value={this.props.initValue}>
+          <select className="uk-select form-horizontal-select" onChange={this.props.onChange} value={this.props.initValue}>
             <option value="">Please Select</option>
             {options}
           </select>
         </div>
       </div>
-
     )
   }
 }

--- a/src/browser/components/molecules/header/index.js
+++ b/src/browser/components/molecules/header/index.js
@@ -34,20 +34,20 @@ export default class Header extends Component {
                                 <div className="uk-margin">
                                     <label className="uk-form-label" htmlFor="form-horizontal-text">What Is Your Question?</label>
                                     <div className="uk-form-controls">
-                                        <input className="uk-input" id="form-horizontal-text" type="text" placeholder="What is the meaning of life, the universe, and everything?" />
+                                        <input className="uk-input form-horizontal-text" type="text" placeholder="What is the meaning of life, the universe, and everything?" />
                                     </div>
                                 </div>
                                 <div className="uk-margin">
                                     <label className="uk-form-label" htmlFor="form-horizontal-text">What Is The Answer?</label>
                                     <div className="uk-form-controls">
 
-                                        <input className="uk-input" id="form-horizontal-text" type="text" placeholder="42" />
+                                        <input className="uk-input form-horizontal-text" type="text" placeholder="42" />
                                     </div>
                                 </div>
                                 <div className="uk-margin">
                                     <label className="uk-form-label" htmlFor="form-horizontal-select">Topic</label>
                                     <div className="uk-form-controls">
-                                        <select className="uk-select" id="form-horizontal-select">
+                                        <select className="uk-select form-horizontal-text">
                                             <option>core-javascript</option>
                                             <option>functional-programming</option>
                                         </select>


### PR DESCRIPTION
Many items had uk styling in the id field, more importantly, those id's we're being repeated. This moves those names into the className to prevent DOM collisions.